### PR TITLE
add requests to requirements.txt

### DIFF
--- a/package/groqchat/requirements.txt
+++ b/package/groqchat/requirements.txt
@@ -4,4 +4,5 @@ soundfile==0.12.1
 sounddevice==0.4.7
 SpeechRecognition
 psutil
+requests
 numpy==1.26.4


### PR DESCRIPTION
When I tried installing using `pipx` and `uv tool`, in both cases requests was missing. I think this change should fix it